### PR TITLE
Fix the cursor position when entering illegal characters or when deleting characters

### DIFF
--- a/sd3save_editor/gui/mainwindow.py
+++ b/sd3save_editor/gui/mainwindow.py
@@ -156,10 +156,11 @@ class MainWindow(QMainWindow):
             self.ui.c2NameLineEdit,
             self.ui.c3NameLineEdit,
         ]:
-            lineEdit.setText(
-                save.char_name_adapter.parse(
-                    save.char_name_adapter.build(
-                        lineEdit.text())))
+            text1 = lineEdit.text()
+            text2 = save.char_name_adapter.parse(save.char_name_adapter.build(text1))
+            position = lineEdit.cursorPosition() + len(text2) - len(text1)
+            lineEdit.setText(text2)
+            lineEdit.setCursorPosition(position)
 
     def initSaveEntryComboBox(self):
         self.ui.saveIndexComboBox.clear()


### PR DESCRIPTION
I came along this problem when using backspace (del key), or when highlighting characters and trying to replace them, or when trying to enter illegal characters for the currently selected encoding. The cursor would jump to a different position other than expected.

I also tried to use a QValidator -- which basically worked as expected -- however, when changing the language encoding using the combo box, the line edit text needed to be re-evaluated, but using setText() does not trigger the validator. So in the end I would have had to call the validator manually anyway. And there is nothing wrong with handling the validator by yourself in the textChanged callback in my opinion.

The problem had already existed since the commit from 2022-08-05. It's fixed now.